### PR TITLE
access key cannot contains spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Let's say you want to send a signed POST request to http://example.com/ using th
     $yourHeaders = array('Content-Type' => 'application/json');
 
     $headersWithAuthInfo = Escher::create('example/credential/scope')
-        ->signRequest('YOUR ACCESS KEY ID', 'YOUR SECRET', $method, $url, $requestBody, $yourHeaders);
+        ->signRequest('YOUR_ACCESS_KEY_ID', 'YOUR SECRET', $method, $url, $requestBody, $yourHeaders);
 
     $client = new GuzzleHttp\Client();
     $response = $client->post($url, array(
@@ -36,7 +36,7 @@ In some cases you may want to send authenticated requests from a context where y
 You can however generate a presigned URL, where the authentication information is added to the query string.
 
     $presignedUrl = Escher::create('example/credential/scope')
-        ->presignUrl('YOUR ACCESS KEY ID', 'YOUR SECRET', 'http://example.com');
+        ->presignUrl('YOUR_ACCESS_KEY_ID', 'YOUR SECRET', 'http://example.com');
 
 
 Validating a request
@@ -47,8 +47,8 @@ Escher accepts any kind of object as a key database that implements the ArrayAcc
 
     try {
         $keyDB = new ArrayObject(array(
-            'ACCESS KEY OF CLIENT 1'  => 'SECRET OF CLIENT 1',
-            'ACCESS KEY OF CLIENT 42' => 'SECRET OF CLIENT 42',
+            'ACCESS_KEY_OF_CLIENT_1'  => 'SECRET OF CLIENT 1',
+            'ACCESS_KEY_OF_CLIENT_42' => 'SECRET OF CLIENT 42',
         ));
         Escher::create('example/credential/scope')->validateRequest($keyDB);
     } catch (EscherException $ex) {


### PR DESCRIPTION
I think, you should specify in your implementation that access key cannot contains spaces; See first explode in class function

```
/**
 * @param $headerContent
 * @param $algoPrefix
 * @return array
 * @throws EscherException
 */
public static function parseAuthHeader($headerContent, $algoPrefix)
{
    $parts = explode(' ', $headerContent);
    if (count($parts) !== 4) {
        throw new EscherException('Could not parse authorization header: ' . $headerContent);
    }
    return array(
        'Algorithm'     => self::match(self::algoPattern($algoPrefix),    $parts[0]),
        'Credentials'   => self::match('Credential=([A-Za-z0-9\/\-_]+),', $parts[1]),
        'SignedHeaders' => self::match('SignedHeaders=([A-Za-z\-;]+),',   $parts[2]),
        'Signature'     => self::match('Signature=([0-9a-f]+)',           $parts[3]),
    );
}
```
